### PR TITLE
Add dynamic setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,20 @@
 **Comment utiliser l'application :**
 
-1.  **Installation des dépendances Python :**
+1.  **Préparation automatique :**
+    * Après avoir cloné le dépôt, exécutez :
+        ```bash
+        python setup.py
+        ```
+    * Le script installera les dépendances manquantes et téléchargera Real‑ESRGAN.
+
+2.  **Installation des dépendances Python :**
     * Assurez-vous d'avoir Python installé.
     * Installez toutes les bibliothèques nécessaires avec :
         ```bash
         pip install -r requirements.txt
         ```
 
-2.  **Télécharger Real-ESRGAN :**
+3.  **Télécharger Real-ESRGAN :**
     * L'application vérifie automatiquement la présence de l'exécutable et du modèle. S'ils sont absents, ils seront téléchargés dans le répertoire du projet.
     * Vous pouvez tout de même déclencher manuellement le téléchargement avec :
         ```bash
@@ -16,24 +23,24 @@
       (par défaut, le téléchargement se fait dans le dossier courant.)
     * Alternativement, rendez-vous sur la page des releases de [Real-ESRGAN](https://github.com/xinntao/Real-ESRGAN/releases) et téléchargez la version `realesrgan-ncnn-vulkan`. Extrayez `realesrgan-ncnn-vulkan.exe` ainsi que le dossier `models`.
 
-3.  **Lancer l'application :**
+4.  **Lancer l'application :**
     * Exécutez simplement :
         ```bash
         python main.py
         ```
 
-4.  **Configuration dans l'interface :**
+5.  **Configuration dans l'interface :**
     * **Répertoire de travail :** Choisissez un dossier où l'application stockera le dépôt cloné, les fichiers extraits, les PNG, etc.
     * **Real-ESRGAN (.exe) :** Indiquez le chemin complet vers `realesrgan-ncnn-vulkan.exe`.
     * **Modèle Real-ESRGAN (nom) :** Entrez le nom du modèle que vous souhaitez utiliser (par exemple, `realesrgan-x4plus-anime` ou `RealESRGAN_x4plus`). Ce nom doit correspondre aux fichiers `.param` et `.bin` présents à côté de l'exécutable ou dans son sous-dossier `models`.
     * **Facteur d'Upscale :** Généralement `4` pour un upscale x4.
 
-5.  **Démarrer le processus :**
+6.  **Démarrer le processus :**
     * Cliquez sur "Démarrer le Processus Complet".
     * Suivez les logs et la barre de progression.
     * À la fin de l'upscaling, une fenêtre de comparaison avant/après vous permettra de valider le résultat.
 
-6.  **Résultats :**
+7.  **Résultats :**
     * Une fois terminé, les fichiers `.FRM` upscalés se trouveront dans le sous-dossier `frm_upscaled_final` de votre répertoire de travail.
     * La structure des dossiers à l'intérieur de `frm_upscaled_final` (par exemple, `master/art/critters/`) devrait correspondre à celle attendue par le jeu.
     * **TRÈS IMPORTANT :** Avant de remplacer des fichiers dans votre installation de Fallout 1 CE, faites une **SAUVEGARDE COMPLÈTE** de votre jeu. Copiez ensuite le contenu de `frm_upscaled_final` dans le répertoire racine de Fallout 1 CE, en écrasant les fichiers existants si nécessaire (ou en les plaçant dans un dossier `data` ou `mods` si le moteur le supporte pour les overrides).
@@ -55,9 +62,16 @@
 * **Pipeline `HybridUpscaler`** combinant Upscayl, ComfyUI et Real‑ESRGAN selon le type d'asset avec validation de qualité (SSIM/PSNR).
 * **Profils configurables** : les paramètres des moteurs et leurs seuils peuvent être sauvegardés dans `~/.ofua_profiles`. Des profils `speed`, `quality`, `balanced` et `fallout_optimized` sont inclus.
 * **Script `setup_enhanced.py`** pour préparer automatiquement l'environnement (installation des dépendances et vérifications système).
+* **Nouveau `setup.py`** : installe les paquets manquants et récupère Real‑ESRGAN en un clic.
 * **Option Direct3D‑S2** : génération de modèles 3D à partir des sprites grâce à un pipeline intégré simplifié.
 
-Pour exécuter ce script :
+Pour préparer rapidement l'environnement :
+
+```bash
+python setup.py
+```
+
+Le script historique reste disponible :
 
 ```bash
 python setup_enhanced.py

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,92 @@
+"""Dynamic environment setup for the Fallout Upscaler application.
+
+This script installs required Python packages listed in requirements.txt,
+checks for external dependencies like git, and optionally clones auxiliary
+repositories (e.g. Real-ESRGAN) if they are missing. Run it once after
+cloning the project to prepare a working environment.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+REQUIREMENTS_FILE = Path("requirements.txt")
+TOOLS_DIR = Path("tools")
+REALESRGAN_REPO = "https://github.com/xinntao/Real-ESRGAN.git"
+REALESRGAN_DIR = TOOLS_DIR / "Real-ESRGAN"
+
+
+def package_installed(pkg: str) -> bool:
+    """Return True if the given package appears importable."""
+    module_name = pkg.split("==")[0].replace("-", "_")
+    return importlib.util.find_spec(module_name) is not None
+
+
+def ensure_packages() -> None:
+    """Install packages from requirements.txt if missing."""
+    if not REQUIREMENTS_FILE.exists():
+        print(f"{REQUIREMENTS_FILE} missing")
+        return
+    with open(REQUIREMENTS_FILE, "r", encoding="utf-8") as fh:
+        packages = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+
+    to_install = [pkg for pkg in packages if not package_installed(pkg)]
+    if to_install:
+        print("Installing Python packages:", ", ".join(to_install))
+        subprocess.check_call([sys.executable, "-m", "pip", "install", *to_install])
+    else:
+        print("All required packages are already installed.")
+
+
+def have_cmd(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def ensure_git() -> None:
+    if not have_cmd("git"):
+        raise EnvironmentError("git command not found. Please install git and re-run this script.")
+
+
+def clone_repo(url: str, dest: Path) -> None:
+    if dest.exists():
+        print(f"Repository already present: {dest}")
+        return
+    print(f"Cloning {url} into {dest}…")
+    subprocess.check_call(["git", "clone", "--depth", "1", url, str(dest)])
+
+
+def setup_external_tools() -> None:
+    TOOLS_DIR.mkdir(exist_ok=True)
+    clone_repo(REALESRGAN_REPO, REALESRGAN_DIR)
+
+
+def create_default_config(cfg_path: Path) -> None:
+    if cfg_path.exists():
+        return
+    cfg = {
+        "workspace": str(Path("fallout_upscaler_workspace").resolve()),
+        "upscale_factor": 4,
+        "realesrgan_dir": str(REALESRGAN_DIR.resolve()),
+    }
+    with open(cfg_path, "w", encoding="utf-8") as fh:
+        json.dump(cfg, fh, indent=2)
+    print(f"Default config created at {cfg_path}")
+
+
+def main() -> None:
+    ensure_git()
+    ensure_packages()
+    setup_external_tools()
+    create_default_config(Path("config.json"))
+    print("Setup complete. You can now run the application with `python main.py`.\n")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- create `setup.py` for dynamic environment setup
- document new script and user workflow in README
- describe quick environment prep and reference old `setup_enhanced.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683bf799e1e08326854d9ece46159c95